### PR TITLE
Fixed yarn mappings downloader using deprecated url

### DIFF
--- a/src/main/java/xyz/jpenilla/betterfabricconsole/remap/YarnMappingsDownloader.java
+++ b/src/main/java/xyz/jpenilla/betterfabricconsole/remap/YarnMappingsDownloader.java
@@ -45,7 +45,7 @@ final class YarnMappingsDownloader implements MappingsDownloader<YarnMappingsDow
   private static final String YARN_MAPPINGS_PATH = MappingsCache.MAPPINGS_PATH + "/yarn/" + MappingsCache.MINECRAFT_VERSION + ".jar";
   private static final String YARN_MAPPINGS_VERSION_PATH = MappingsCache.MAPPINGS_PATH + "/yarn/" + MappingsCache.MINECRAFT_VERSION + "-current-yarn.txt";
   private static final String YARN_URL = "https://maven.fabricmc.net/net/fabricmc/yarn/{}/yarn-{}-mergedv2.jar";
-  private static final String YARN_VERSIONS_URL = "https://maven.fabricmc.net/net/fabricmc/yarn/versions.json";
+  private static final String YARN_VERSIONS_URL = "https://meta.fabricmc.net/v2/versions/yarn";
 
   private final Path cache;
 

--- a/src/main/java/xyz/jpenilla/betterfabricconsole/remap/YarnMappingsDownloader.java
+++ b/src/main/java/xyz/jpenilla/betterfabricconsole/remap/YarnMappingsDownloader.java
@@ -23,8 +23,8 @@
  */
 package xyz.jpenilla.betterfabricconsole.remap;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.mojang.logging.LogUtils;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -78,16 +78,17 @@ final class YarnMappingsDownloader implements MappingsDownloader<YarnMappingsDow
   }
 
   private static @Nullable Integer findLatestYarnBuildForMcVersion(final Path yarnVersionsPath) throws IOException {
-    final JsonObject yarnVersions;
+    final JsonElement root;
     try (final BufferedReader reader = Files.newBufferedReader(yarnVersionsPath)) {
-      yarnVersions = MappingsCache.GSON.fromJson(reader, JsonObject.class);
+      root = MappingsCache.GSON.fromJson(reader, JsonElement.class);
     }
-    final JsonElement element = yarnVersions.get(MappingsCache.MINECRAFT_VERSION);
-    if (element == null) {
+    if (!(root instanceof JsonArray yarnVersions)) {
       return null;
     }
-    return StreamSupport.stream(element.getAsJsonArray().spliterator(), false)
-      .map(JsonElement::getAsInt)
+    return StreamSupport.stream(yarnVersions.spliterator(), false)
+      .map(JsonElement::getAsJsonObject)
+      .filter(element -> element.get("gameVersion").getAsString().equals(MappingsCache.MINECRAFT_VERSION))
+      .map(object -> object.get("build").getAsInt())
       .max(Comparator.naturalOrder())
       .orElse(null);
   }


### PR DESCRIPTION
This changes the url from which yarn mappings are downloaded from the deprecated https://maven.fabricmc.net/net/fabricmc/yarn/versions.json to the new https://meta.fabricmc.net/v2/versions/yarn

Due to this having a new file structure, this also updates the parsing. If the old yarn-versions.json file is found it will no longer parse those, causing a re-download of the new versions from meta.fabricmc.net.

Fixes #31